### PR TITLE
Add more keywords

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,12 +6,16 @@
   ],
   "keywords": [
     "web-component",
+    "polymer-element",
     "polymer",
+    "polymer-2",
+    "polymer-2-hybrid",
     "device",
     "position",
     "orientation",
     "motion",
-    "sensor"
+    "sensor",
+    "api"
   ],
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
* Add `polymer-element`, `polymer-2` and `polymer-2-hybrid` keywords to `bower.json` file to indicate that this is Polymer 1.x/2.x hybrid element.
* Add `api` keywords to `bower.json` file because `<device-orientation>` web component is a part of my [progressive-elements](https://www.webcomponents.org/collection/FluorescentHallucinogen/progressive-elements) collection that is a set of web components for [modern web APIs](https://whatwebcando.today) such as Payment Request API, Media Session API, etc. People can find these web components by the `api` keyword.